### PR TITLE
Provide "Untitled" as default note title

### DIFF
--- a/app/src/main/java/com/foxmobile/foxnotemini/composables/NoteConteiner.kt
+++ b/app/src/main/java/com/foxmobile/foxnotemini/composables/NoteConteiner.kt
@@ -59,7 +59,7 @@ fun NoteContainer(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     content = {
                         Text(
-                            note.title,
+                            note.title.ifEmpty { "Untitled" },
                             color = MaterialTheme.colorScheme.primary,
                             fontSize = 25.sp,
                             textAlign = TextAlign.Center,


### PR DESCRIPTION
If a note's title is empty, it will now be displayed as "Untitled" in the `NoteContainer`.